### PR TITLE
FIX: Change .gitignore references to WezTerm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,10 +37,8 @@ Components/Nvim/lazy-lock.json
 !Components/PowerShell/*
 
 # Terminal
-!Components/Terminal
+!Components/WezTerm
 !Components/Terminal/*
-!Components/Terminal/TerminalIcons
-!Components/Terminal/TerminalIcons/*
 
 # VSCode
 !Components/VSCode


### PR DESCRIPTION
**Updates**

- Change .gitignore references to be WezTerm instead of Windows Terminal