### PR TITLE
Added authentication and sysadmin helper functions

### DIFF
--- a/Components/PowerShell/config/Aliases.ps1
+++ b/Components/PowerShell/config/Aliases.ps1
@@ -6,3 +6,4 @@
 #>
 
 Set-Alias -Name which -Value Get-Command
+Set-Alias -Name grep -Value Select-String

--- a/Components/PowerShell/functions/ActiveDirectory.ps1
+++ b/Components/PowerShell/functions/ActiveDirectory.ps1
@@ -1,0 +1,62 @@
+function Unlock-AdUser {
+<#
+.SYNOPSIS
+    Unlocks Active Directory user accounts.
+.DESCRIPTION
+    Unlocks a specific Active Directory user account when an identity is supplied.
+    If no identity is supplied, all currently locked Active Directory user accounts are found and unlocked.
+    This function uses the administrative credential stored by Connect-Admin.
+.PARAMETER Identity
+    The specific user account to unlock. If omitted, all locked accounts are unlocked.
+.EXAMPLE
+    Unlock jsmith
+    Unlocks the jsmith account.
+.EXAMPLE
+    Unlock
+    Finds and unlocks all currently locked Active Directory user accounts.
+.EXAMPLE
+    Unlock -Verbose
+    Finds and unlocks all locked accounts, displaying each account as it is unlocked.
+.EXAMPLE
+    Unlock -WhatIf
+    Shows which accounts would be unlocked without making changes.
+#>
+    [CmdletBinding(SupportsShouldProcess)]
+    [Alias('unlock')]
+    param(
+        [Parameter(Position = 0)]
+        [string] $Identity
+    )
+
+    if (-not (Get-Module -ListAvailable -Name ActiveDirectory)) {
+        throw 'ActiveDirectory module is not available.'
+    }
+
+    Import-Module ActiveDirectory
+
+    $Credential = Get-AdminCredential
+
+    $AdParameters = @{
+        Credential = $Credential
+    }
+
+    if ($Identity) {
+        Write-Verbose "Unlocking AD account: $Identity"
+
+        if ($PSCmdlet.ShouldProcess($Identity, 'Unlock AD account')) {
+            Unlock-ADAccount -Identity $Identity @AdParameters
+        }
+
+        return
+    }
+
+    $LockedUsers = Search-ADAccount -LockedOut -UsersOnly @AdParameters
+
+    foreach ($User in $LockedUsers) {
+        Write-Verbose "Unlocking AD account: $($User.SamAccountName)"
+
+        if ($PSCmdlet.ShouldProcess($User.SamAccountName, 'Unlock AD account')) {
+            Unlock-ADAccount -Identity $User.SamAccountName @AdParameters
+        }
+    }
+}

--- a/Components/PowerShell/functions/Authentication.ps1
+++ b/Components/PowerShell/functions/Authentication.ps1
@@ -1,0 +1,93 @@
+function Connect-Admin {
+<#
+.SYNOPSIS
+    Stores an administrative credential for the current PowerShell session.
+.DESCRIPTION
+    Prompts for administrative credentials and stores them in memory for use by other helper functions during the current PowerShell session.
+.PARAMETER TimeoutHours
+    The number of hours before the stored credential expires.
+.EXAMPLE
+    Connect-Admin
+.EXAMPLE
+    admin
+.EXAMPLE
+    Connect-Admin -TimeoutHours 2
+#>
+    [CmdletBinding()]
+    [Alias('admin')]
+
+    param(
+        [int] $TimeoutHours = 4
+    )
+
+    $Script:AdminCredential = Get-Credential
+    $Script:AdminCredentialExpires = (Get-Date).AddHours($TimeoutHours)
+
+    Write-Verbose "Administrative credential stored until $Script:AdminCredentialExpires."
+}
+
+function Disconnect-Admin {
+<#
+.SYNOPSIS
+    Removes the stored administrative credential.
+.DESCRIPTION
+    Clears the stored administrative credential from the current PowerShell session.
+.EXAMPLE
+    Disconnect-Admin
+.EXAMPLE
+    adminoff
+#>
+    [CmdletBinding()]
+
+    param()
+
+    Remove-Variable -Name AdminCredential -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name AdminCredentialExpires -Scope Script -ErrorAction SilentlyContinue
+
+    Write-Verbose 'Administrative credential removed.'
+}
+
+function Test-AdminCredential {
+<#
+.SYNOPSIS
+    Tests whether an administrative credential is available.
+.DESCRIPTION
+    Returns true if an administrative credential exists and has not expired.
+    Returns false if no credential exists or the stored credential has expired.
+.EXAMPLE
+    Test-AdminCredential
+#>
+    [CmdletBinding()]
+    param()
+
+    if (-not $Script:AdminCredential) {
+        return $false
+    }
+
+    if ($Script:AdminCredentialExpires -and (Get-Date) -gt $Script:AdminCredentialExpires) {
+        Disconnect-Admin
+        return $false
+    }
+
+    return $true
+}
+
+function Get-AdminCredential {
+<#
+.SYNOPSIS
+    Gets the stored administrative credential.
+.DESCRIPTION
+    Returns the stored administrative credential if one exists and has not expired.
+    If no valid credential exists, an error is thrown.
+.EXAMPLE
+    Get-AdminCredential
+#>
+    [CmdletBinding()]
+    param()
+
+    if (-not (Test-AdminCredential)) {
+        throw 'No valid administrative credential found. Run Connect-Admin first.'
+    }
+
+    return $Script:AdminCredential
+}

--- a/Components/PowerShell/functions/FileSystem.ps1
+++ b/Components/PowerShell/functions/FileSystem.ps1
@@ -17,7 +17,7 @@ function New-File {
     Creates a file named roadmap.md in the docs directory.
 #>
     [CmdletBinding()]
-    [Alias('nf')]
+    [Alias('nf','touch')]
 
     param(
         [Parameter(Mandatory)]

--- a/Components/PowerShell/functions/Remoting.ps1
+++ b/Components/PowerShell/functions/Remoting.ps1
@@ -1,0 +1,36 @@
+function Connect-PSSession {
+<#
+.SYNOPSIS
+    Starts a PowerShell remoting session.
+.DESCRIPTION
+    Starts an interactive PowerShell remoting session using Enter-PSSession.
+.PARAMETER ComputerName
+    The remote computer to connect to.
+.PARAMETER Credential
+    The credential to use for the remoting session.
+.EXAMPLE
+    Connect-PSSession -ComputerName SERVER01
+    Prompts for credentials and connects to SERVER01.
+.EXAMPLE
+    pss SERVER01
+    Prompts for credentials and connects to SERVER01.
+.EXAMPLE
+    pss SERVER01 -Credential $Credential
+    Connects to SERVER01 using the supplied credential.
+#>
+    [CmdletBinding()]
+    [Alias('pss')]
+
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string] $ComputerName,
+
+        [System.Management.Automation.PSCredential] $Credential
+    )
+
+    if (-not $Credential) {
+        $Credential = Get-Credential
+    }
+
+    Enter-PSSession -ComputerName $ComputerName -Credential $Credential
+}


### PR DESCRIPTION
## Summary

Adds the initial sysadmin helper framework for day-to-day administration tasks.

### Included

- Authentication helper functions
  - Connect-Admin
  - Disconnect-Admin
  - Test-AdminCredential
  - Get-AdminCredential

- Active Directory helper functions
  - Unlock-AdUser

- PowerShell remoting helper functions
  - Connect-PSSession

- Updated aliases and supporting PowerShell functions

### Notes

- Credentials are stored in memory only
- Credentials automatically expire after a configurable timeout
- Active Directory functions now use the stored administrative credential

Related Issues:
- #38 